### PR TITLE
Feat : [#issueNumber-1] 메인 페이지 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,9 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.postgresql:postgresql'
+    compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/gradlew
+++ b/gradlew
@@ -32,7 +32,7 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
+#         * expansions «$var», «${var}», «${var:-fix}», «${var+SET}»,
 #           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
 #         * compound commands having a testable exit status, especially «case»;
 #         * various built-in commands including «command», «set», and «ulimit».

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/controller/CustomExtensionController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/controller/CustomExtensionController.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.custom_extension.controller;
-
-public class CustomExtensionController {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/dto/CustomExtensionCreateRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/dto/CustomExtensionCreateRequest.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.custom_extension.dto;
-
-public class CustomExtensionCreateRequest {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/entity/CustomExtension.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/entity/CustomExtension.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.custom_extension.entity;
-
-public class CustomExtension {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/exception/SampleException.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/exception/SampleException.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.custom_extension.exception;
-
-public class SampleException {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/repository/CustomExtensionRepository.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/repository/CustomExtensionRepository.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.custom_extension.repository;
-
-public interface CustomExtensionRepository {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/service/CustomExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/custom_extension/service/CustomExtensionService.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.custom_extension.service;
-
-public class CustomExtensionService {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/controller/DefaultExtensionController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/controller/DefaultExtensionController.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.default_extension.controller;
-
-public class DefaultExtensionController {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/dto/DefaultExtensionCreateRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/dto/DefaultExtensionCreateRequest.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.default_extension.dto;
-
-public class DefaultExtensionCreateRequest {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/entity/DefaultExtension.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/entity/DefaultExtension.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.default_extension.entity;
-
-public class DefaultExtension {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/exception/SampleException.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/exception/SampleException.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.default_extension.exception;
-
-public class SampleException {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/repository/DefaultExtensionRepository.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/repository/DefaultExtensionRepository.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.default_extension.repository;
-
-public interface DefaultExtensionRepository {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/service/DefaultExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/default_extension/service/DefaultExtensionService.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.default_extension.service;
-
-public class DefaultExtensionService {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/extension/controller/CustomExtensionController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/extension/controller/CustomExtensionController.java
@@ -1,0 +1,10 @@
+package com.flowhyemin.extensionfilter.domain.extension.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class CustomExtensionController {
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/extension/controller/FixExtensionController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/extension/controller/FixExtensionController.java
@@ -1,0 +1,9 @@
+package com.flowhyemin.extensionfilter.domain.extension.controller;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@AllArgsConstructor
+public class FixExtensionController {
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/extension/controller/HomeController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/extension/controller/HomeController.java
@@ -1,0 +1,28 @@
+package com.flowhyemin.extensionfilter.domain.extension.controller;
+
+import com.flowhyemin.extensionfilter.domain.extension.entity.Extension;
+import com.flowhyemin.extensionfilter.domain.extension.service.CustomExtensionService;
+import com.flowhyemin.extensionfilter.domain.extension.service.FixExtensionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class HomeController {
+    private final CustomExtensionService customExtensionService;
+    private final FixExtensionService fixExtensionService;
+
+    @GetMapping("/")
+    public String home(Model model) {
+        List<Extension> fixExtensionList = fixExtensionService.findAllFixExtension();
+        List<Extension> customList = customExtensionService.findAllCustomExtension();
+
+        model.addAttribute("fixList", fixExtensionList);
+        model.addAttribute("customList", customList);
+        return "home";
+    }
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/extension/dto/CustomExtensionCreateRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/extension/dto/CustomExtensionCreateRequest.java
@@ -1,0 +1,4 @@
+package com.flowhyemin.extensionfilter.domain.extension.dto;
+
+public class CustomExtensionCreateRequest {
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/extension/entity/Extension.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/extension/entity/Extension.java
@@ -1,0 +1,20 @@
+package com.flowhyemin.extensionfilter.domain.extension.entity;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+public class Extension {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private Boolean name;
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean isDefault;
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean isFixed;
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/extension/exception/SampleException.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/extension/exception/SampleException.java
@@ -1,0 +1,4 @@
+package com.flowhyemin.extensionfilter.domain.extension.exception;
+
+public class SampleException {
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/extension/repository/ExtensionRepository.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/extension/repository/ExtensionRepository.java
@@ -1,0 +1,7 @@
+package com.flowhyemin.extensionfilter.domain.extension.repository;
+
+import com.flowhyemin.extensionfilter.domain.extension.entity.Extension;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExtensionRepository extends JpaRepository<Extension,Long> {
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/extension/service/CustomExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/extension/service/CustomExtensionService.java
@@ -1,0 +1,17 @@
+package com.flowhyemin.extensionfilter.domain.extension.service;
+
+import com.flowhyemin.extensionfilter.domain.extension.entity.Extension;
+import com.flowhyemin.extensionfilter.domain.extension.repository.ExtensionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomExtensionService {
+    private final ExtensionRepository extensionRepository;
+    public List<Extension> findAllCustomExtension() {
+        return null;
+    }
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/extension/service/FixExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/extension/service/FixExtensionService.java
@@ -1,0 +1,18 @@
+package com.flowhyemin.extensionfilter.domain.extension.service;
+
+import com.flowhyemin.extensionfilter.domain.extension.entity.Extension;
+import com.flowhyemin.extensionfilter.domain.extension.repository.ExtensionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FixExtensionService {
+    private final ExtensionRepository extensionRepository;
+    public List<Extension> findAllFixExtension() {
+
+        return null;
+    }
+}

--- a/src/main/resources/static/css/reset.css
+++ b/src/main/resources/static/css/reset.css
@@ -1,0 +1,62 @@
+/* nanumsquare 웹 폰트 */
+@import url('https://cdn.jsdelivr.net/gh/moonspam/NanumSquare@2.0/nanumsquare.css');
+
+* {
+  margin: 0;
+  font-family : 'NanumSquare', sans-serif;
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
+  color: var(--dark);
+}
+
+html,body {
+  font-family : 'NanumSquare', sans-serif;
+  color: var(--dark);
+}
+
+
+h1 {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+input,textarea {
+  background-color: transparent;
+  border: 0;
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+}
+
+button,
+select
+ {
+  background-color: #b7b7b7;
+  border: 0;
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+}
+
+a,
+button {
+  cursor: pointer;
+}
+
+ol,
+ul,
+li {
+  padding-left: 0;
+  list-style: none;
+}
+

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
+          integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA=="
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer"/>
+
+    <link rel="stylesheet" th:href="@{/css/style.css}" href="../static/css/style.css"/>
+  </head>
+  <body>
+    <div class="container">
+
+      <section class="fix-extension">
+        <div class="section-header">
+          <h3 class="section-title">고정 확장자</h3>
+        </div>
+
+        <ul class="fix-extension-list">
+          <li class="fix-extension-item" th:each="fix : ${fixList}">
+            <input
+              type="checkbox"
+              th:name="${fix.name}"
+              th:id="${fix.name}"
+            />
+
+            <label
+              th:text="${fix.name}"
+              th:class="${fix.checked == 'Y'} ? 'button active' : 'button'"
+              >fixExtensionName</label
+            >
+          </li>
+        </ul>
+      </section>
+
+      <section class="custom-extension">
+        <div class="section-header">
+          <h3 class="section-title">커스텀 확장자</h3>
+          <div class="reset-button custom">
+            <span>초기화 하기</span>
+            <i class="refresh-icon fa-solid fa-rotate-right"></i>
+          </div>
+        </div>
+
+        <div class="valid-check-info">
+          <i class="fa-solid fa-circle-info"></i>
+          <span
+            >확장자는 영문 대소문자로, 최대 20글자까지 입력 가능합니다.</span
+          >
+        </div>
+
+        <div class="custom-extension-input-area">
+          <input
+            type="text"
+            placeholder="확장자를 입력해주세요"
+            maxlength="20"
+          />
+          <button class="add-button button">
+            <i class="fa-solid fa-plus"></i>
+            추가
+          </button>
+        </div>
+
+        <div class="custom-extension-saved-area">
+          <div class="custom-extension-count">
+<!--            <span class="current" th:text="${#lists.size(customList)}">0</span>-->
+            / 200
+          </div>
+
+          <ul class="custom-extension-list">
+            <li
+              class="custom-extension-item button"
+              th:each="custom : ${customList}"
+            >
+              <span class="custom-extension-name" th:text="${custom.name}"
+                >CustomExtensionName</span
+              >
+              <button class="delete">
+                <i class="fa-solid fa-xmark"></i>
+              </button>
+            </li>
+          </ul>
+        </div>
+      </section>
+    </div>
+
+    <script th:src="@{js/index.js}" src="../static/js/index.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
+            integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer">
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 작업 요약
- HomeController 내 메인 페이지 조회 api 구현
- PostgreSQL (RDS) 연결 설정 완료
- 메인페이지 html 프레임 구현 완료

## Issue Link
#1

## 문제점 및 어려움
- 고정 확장자와 커스텀 확장자의 엔티티(테이블) 하위 칼럼 중 겹치는 칼럼이 많아 엔티티 분리 여부 결정 필요

## 해결 방안
- Boolean 타입의 isFixed 칼럼으로 고정 확장자와 커스텀 확장자 구분 / 엔티티는 한개로 활용
    > 위 방법은 향후 고정 확장자 종류의 추가 및 삭제 등 용이 (유지보수성 확보)
## Reference
