### PR TITLE
Hotfix : [#issueNumber-7] 고정 확장자 체크 박스 클릭 시 DB 반영

### DIFF
--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckRequest.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class FixExtensionCheckRequest {
     private String name;
-    private Boolean isChecked;
+    private String isChecked;
 
     public FixExtension toEntity() {
         return FixExtension.builder()

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckResponse.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckResponse.java
@@ -10,7 +10,7 @@ import lombok.*;
 public class FixExtensionCheckResponse {
     private Long id;
     private String name;
-    private Boolean isChecked;
+    private String isChecked;
 
     public static FixExtensionCheckResponse fromEntity(FixExtension fixExtension) {
         return FixExtensionCheckResponse.builder()

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateRequest.java
@@ -15,7 +15,7 @@ public class FixExtensionCreateRequest {
     public FixExtension toEntity() {
         return FixExtension.builder()
             .name(name)
-            .isChecked(false)
+            .isChecked("false")
             .build();
     }
 }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateResponse.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateResponse.java
@@ -10,7 +10,7 @@ import lombok.*;
 public class FixExtensionCreateResponse {
     private Long id;
     private String name;
-    private Boolean isChecked;
+    private String isChecked;
 
     public static FixExtensionCreateResponse fromEntity(FixExtension fixExtension) {
         return FixExtensionCreateResponse.builder()

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionGetResponse.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionGetResponse.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Builder
 public class FixExtensionGetResponse {
     private String name;
-    private Boolean isChecked;
+    private String isChecked;
 
     public static FixExtensionGetResponse fromEntity(FixExtension fixExtension) {
         return FixExtensionGetResponse.builder()

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/entity/FixExtension.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/entity/FixExtension.java
@@ -18,9 +18,9 @@ public class FixExtension {
     private String name;
     @Column(nullable = false)
     @ColumnDefault("false")
-    private Boolean isChecked;
+    private String isChecked;
 
-    public void updateFixExtension(Boolean isChecked) {
+    public void updateFixExtension(String isChecked) {
         this.isChecked = isChecked;
     }
 }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/repository/FixExtensionRepository.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/repository/FixExtensionRepository.java
@@ -7,11 +7,14 @@ import java.util.List;
 
 public interface FixExtensionRepository extends JpaRepository<FixExtension,Long> {
 
-    List<FixExtension> findAllByIsChecked(Boolean ischecked);
+    List<FixExtension> findAllByIsChecked(String ischecked);
 
     FixExtension findByName(String name);
 
 
     void deleteByName(String name);
+
+
+    List<FixExtension> findAllByOrderByIdAsc();
 }
 

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
@@ -16,7 +16,7 @@ public class FixExtensionService {
     private final FixExtensionRepository fixExtensionRepository;
     @Transactional(readOnly = true)
     public List<FixExtensionGetResponse> findAllFixExtension() {
-        return fixExtensionRepository.findAll().stream()
+        return fixExtensionRepository.findAllByOrderByIdAsc().stream()
             .map(FixExtensionGetResponse::fromEntity)
             .collect(Collectors.toList());
     }

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -1,6 +1,6 @@
 // Variables
 
-const fixedExtensionItemButtons = document.querySelectorAll(
+const fixExtensionItemButtons = document.querySelectorAll(
   ".fix-extension-item .button"
 );
 const customExtensionInput = document.querySelector(
@@ -14,24 +14,16 @@ const addFixByButton = document.querySelector(".fix-extension-add-button");
 const deleteFixByButton = document.querySelector(".fix-extension-delete-button");
 let deleteButtons = document.querySelectorAll(".delete");
 
-const fileInput = document.getElementById("file");
-const fileText = document.querySelector(".file > span");
-const submitButton = document.querySelector(".submit");
 
 const resetButtons = document.querySelectorAll(".reset-button");
-
-const Type = {
-  Fixed: "F",
-  Custom: "C",
-};
 
 // Events
 
 /**
- * 고정 확장자 버튼 클릭 이벤트
+ * 고정 확장자 체크박스 클릭 이벤트
  * */
-fixedExtensionItemButtons.forEach((checkbox) => {
-  checkbox.addEventListener("click", function () {
+fixExtensionItemButtons.forEach((checkbox) => {
+  checkbox.addEventListener("click", function (event) {
     // 스타일 적용
     this.classList.toggle("active");
 
@@ -41,10 +33,6 @@ fixedExtensionItemButtons.forEach((checkbox) => {
     updateExtensionChecked(extensionName, isChecked);
   });
 });
-
-/**
- * 고정 확장자 체크박스 클릭 이벤트
- * */
 
 
 /**

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -29,7 +29,8 @@
               type="checkbox"
               th:name="${fix.name}"
               th:id="${fix.name}"
-              th:class="${fix.isChecked == true} ? 'button active' : 'button'"
+              th:class="${fix.isChecked == 'true'} ? 'button active' : 'button'"
+              th:checked="${fix.isChecked}"
             />
 
             <label


### PR DESCRIPTION
## 작업 요약
- 새로고침 후에도 체크박스 check/uncheck 유지
- check/uncheck 여부에 따라 순서 바뀌는 버그 해결
## Issue Link
#7 
## 문제점 및 어려움
1. 새로고침 시 DB 값은 변경되나, 화면 상 체크박스 체크는 풀리는 버그 발생
2. check/uncheck 여부에 따라 순서 바뀌는 버그 해결
## 해결 방안
1. 타임리프 활용하여 고정 확장자의 isChecked 값 불러와서 유지 (th:checked)
3. 고정 확장자에서 findAll 메서드를 findAllByOrderByIdAsc 로 변경(JPA 활용)
## Reference
