### PR TITLE
Feat : [#issueNumber-9] 커스텀확장자 예외처리 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/controller/CustomExtensionController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/controller/CustomExtensionController.java
@@ -5,6 +5,7 @@ import com.flowhyemin.extensionfilter.domain.customextension.dto.CustomExtension
 import com.flowhyemin.extensionfilter.domain.customextension.dto.CustomExtensionDeleteRequest;
 import com.flowhyemin.extensionfilter.domain.customextension.dto.CustomExtensionDeleteResponse;
 import com.flowhyemin.extensionfilter.domain.customextension.service.CustomExtensionService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +18,7 @@ public class CustomExtensionController {
 
     @PostMapping("/")
     @ResponseBody
-    public boolean createCustomExtension(@RequestBody CustomExtensionCreateRequest customExtensionCreateRequest) {
+    public boolean createCustomExtension(@Valid @RequestBody CustomExtensionCreateRequest customExtensionCreateRequest) {
         customExtensionService.createCustomExtension(customExtensionCreateRequest);
         return true;
     }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionCreateRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionCreateRequest.java
@@ -1,6 +1,8 @@
 package com.flowhyemin.extensionfilter.domain.customextension.dto;
 
 import com.flowhyemin.extensionfilter.domain.customextension.entity.CustomExtension;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CustomExtensionCreateRequest {
+    @Size(min = 1,max = 20)
+    @Pattern(regexp = "^[a-z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
 
     public CustomExtension toEntity() {

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/exception/CustomExtensionException.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/exception/CustomExtensionException.java
@@ -1,0 +1,14 @@
+package com.flowhyemin.extensionfilter.domain.customextension.exception;
+
+import com.flowhyemin.extensionfilter.global.exception.BaseException;
+import com.flowhyemin.extensionfilter.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomExtensionException extends BaseException {
+    private final ErrorCode errorCode;
+    public CustomExtensionException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/exception/SampleException.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/exception/SampleException.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.customextension.exception;
-
-public class SampleException {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/repository/CustomExtensionRepository.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/repository/CustomExtensionRepository.java
@@ -3,8 +3,12 @@ package com.flowhyemin.extensionfilter.domain.customextension.repository;
 import com.flowhyemin.extensionfilter.domain.customextension.entity.CustomExtension;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CustomExtensionRepository extends JpaRepository<CustomExtension,Long> {
 
     void deleteByName(String name);
+
+    Optional<CustomExtension> findByName(String name);
 }
 

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/controller/FixExtensionController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/controller/FixExtensionController.java
@@ -4,6 +4,7 @@ import com.flowhyemin.extensionfilter.domain.fixextension.dto.FixExtensionCheckR
 import com.flowhyemin.extensionfilter.domain.fixextension.dto.FixExtensionCreateRequest;
 import com.flowhyemin.extensionfilter.domain.fixextension.dto.FixExtensionDeleteRequest;
 import com.flowhyemin.extensionfilter.domain.fixextension.service.FixExtensionService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -16,7 +17,7 @@ public class FixExtensionController {
 
     @PostMapping("/")
     @ResponseBody
-    public boolean createFixExtension(@RequestBody FixExtensionCreateRequest fixExtensionCreateRequest) {
+    public boolean createFixExtension(@Valid @RequestBody FixExtensionCreateRequest fixExtensionCreateRequest) {
         fixExtensionService.createFixExtension(fixExtensionCreateRequest);
         return true;
     }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckRequest.java
@@ -1,6 +1,8 @@
 package com.flowhyemin.extensionfilter.domain.fixextension.dto;
 
 import com.flowhyemin.extensionfilter.domain.fixextension.entity.FixExtension;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class FixExtensionCheckRequest {
+    @Size(min = 1,max = 20)
+    @Pattern(regexp = "^[a-z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
     private String isChecked;
 

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/repository/FixExtensionRepository.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/repository/FixExtensionRepository.java
@@ -4,12 +4,13 @@ import com.flowhyemin.extensionfilter.domain.fixextension.entity.FixExtension;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FixExtensionRepository extends JpaRepository<FixExtension,Long> {
 
     List<FixExtension> findAllByIsChecked(String ischecked);
 
-    FixExtension findByName(String name);
+    Optional<FixExtension> findByName(String name);
 
 
     void deleteByName(String name);

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
@@ -29,7 +29,7 @@ public class FixExtensionService {
     }
     @Transactional
     public void checkFixExtension(FixExtensionCheckRequest fixExtensionCheckRequest) {
-        FixExtension fixExtension = fixExtensionRepository.findByName(fixExtensionCheckRequest.getName());
+        FixExtension fixExtension = fixExtensionRepository.findByName(fixExtensionCheckRequest.getName()).orElseThrow();
         fixExtension.updateFixExtension(fixExtensionCheckRequest.getIsChecked());
     }
     @Transactional

--- a/src/main/java/com/flowhyemin/extensionfilter/global/exception/BaseException.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/global/exception/BaseException.java
@@ -1,0 +1,17 @@
+package com.flowhyemin.extensionfilter.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public Integer getCode() {
+        return errorCode.getCode();
+    }
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/global/exception/ErrorCode.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/global/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.flowhyemin.extensionfilter.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    //커스텀 확장자
+    DUPLICATED_CUSTOM_EXTENSION(1001, "이미 등록된 확장자입니다."),
+    EXCEEDED_CUSTOM_EXTENSION_REGISTRAION(1002,"등록 가능한 커스텀 확장자 수를 초과했습니다.")
+
+    ;
+
+    private final Integer code;
+    private final String message;
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,12 @@
+package com.flowhyemin.extensionfilter.global.exception;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BaseException.class)
+    public boolean handleBaseException(BaseException e) {
+        return false;
+    }
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/global/exception/SampleException.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/global/exception/SampleException.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.global.exception;
-
-public class SampleException {
-}


### PR DESCRIPTION
## 작업 요약
- GlobalExceptionHandler 클래스 내 @ControllerAdvice 구현
- 커스텀 확장자 생성 시 예외처리 구현
- ex) 글자수(1~20자),중복등록방지,영문소문자만 등록가능,빈값방지,200개 초과 시 등록 제한
## Issue Link
#9 
## 문제점 및 어려움
1. 프론트엔드 레이어에서 각종 예외처리를 막아두었어도, url로 다이렉트 요청(ex.postman)을 보낼 경우 설정한 예외가 동작하지 않음.
## 해결 방안
1. 백엔드 측 예외처리 구현 필수 / validation 의존성 추가 및 서비스 레이어에서 예외처리 코드 추가
## Reference
