### PR TITLE
Feat : [#issueNumber-10] 커스텀확장자 예외처리 로직 구현

### DIFF
--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/controller/CustomExtensionController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/controller/CustomExtensionController.java
@@ -25,7 +25,7 @@ public class CustomExtensionController {
 
     @DeleteMapping("/")
     @ResponseBody
-    public boolean deleteCustomExtension(@RequestBody CustomExtensionDeleteRequest customExtensionDeleteRequest) {
+    public boolean deleteCustomExtension(@Valid @RequestBody CustomExtensionDeleteRequest customExtensionDeleteRequest) {
         customExtensionService.deleteCustomExtension(customExtensionDeleteRequest);
         return true;
     }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionCreateRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionCreateRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CustomExtensionCreateRequest {
-    @Size(min = 1,max = 20)
+    @Size(min = 1,max = 20,message = "크기가 1에서 20 사이여야 합니다.")
     @Pattern(regexp = "^[a-z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
 

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionDeleteRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionDeleteRequest.java
@@ -1,6 +1,8 @@
 package com.flowhyemin.extensionfilter.domain.customextension.dto;
 
 import com.flowhyemin.extensionfilter.domain.customextension.entity.CustomExtension;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CustomExtensionDeleteRequest {
+    @Size(min = 1,max = 20,message = "크기가 1에서 20 사이여야 합니다.")
+    @Pattern(regexp = "^[a-z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
 
     public CustomExtension toEntity() {

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionGetResponse.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionGetResponse.java
@@ -1,0 +1,18 @@
+package com.flowhyemin.extensionfilter.domain.customextension.dto;
+
+import com.flowhyemin.extensionfilter.domain.customextension.entity.CustomExtension;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CustomExtensionGetResponse {
+    private String name;
+
+    public static CustomExtensionGetResponse fromEntity(CustomExtension customExtension) {
+        return CustomExtensionGetResponse.builder()
+            .name(customExtension.getName())
+            .build();
+    }
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/service/CustomExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/service/CustomExtensionService.java
@@ -1,9 +1,6 @@
 package com.flowhyemin.extensionfilter.domain.customextension.service;
 
-import com.flowhyemin.extensionfilter.domain.customextension.dto.CustomExtensionCreateRequest;
-import com.flowhyemin.extensionfilter.domain.customextension.dto.CustomExtensionCreateResponse;
-import com.flowhyemin.extensionfilter.domain.customextension.dto.CustomExtensionDeleteRequest;
-import com.flowhyemin.extensionfilter.domain.customextension.dto.CustomExtensionDeleteResponse;
+import com.flowhyemin.extensionfilter.domain.customextension.dto.*;
 import com.flowhyemin.extensionfilter.domain.customextension.entity.CustomExtension;
 import com.flowhyemin.extensionfilter.domain.customextension.exception.CustomExtensionException;
 import com.flowhyemin.extensionfilter.domain.customextension.repository.CustomExtensionRepository;
@@ -14,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +34,9 @@ public class CustomExtensionService {
     }
     @Transactional
     public CustomExtensionDeleteResponse deleteCustomExtension(CustomExtensionDeleteRequest customExtensionDeleteRequest) {
-        CustomExtension customExtension = customExtensionDeleteRequest.toEntity();
+        CustomExtension customExtension = customExtensionRepository.findByName(customExtensionDeleteRequest.getName())
+            .orElseThrow(() -> new CustomExtensionException(ErrorCode.NONE_EXISTENCE_CUSTOM_EXTENSION)
+        );
         customExtensionRepository.deleteByName(customExtensionDeleteRequest.getName());
         return CustomExtensionDeleteResponse.fromEntity(customExtension);
     }
@@ -45,7 +45,10 @@ public class CustomExtensionService {
         customExtensionRepository.deleteAll();
     }
     @Transactional(readOnly = true)
-    public List<CustomExtension> findAllCustomExtension() {
-        return customExtensionRepository.findAll();
+    public List<CustomExtensionGetResponse> findAllCustomExtension() {
+        return customExtensionRepository.findAll().stream()
+            .map(CustomExtensionGetResponse::fromEntity)
+            .collect(Collectors.toList());
+
     }
 }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
@@ -14,12 +14,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FixExtensionService {
     private final FixExtensionRepository fixExtensionRepository;
-    @Transactional(readOnly = true)
-    public List<FixExtensionGetResponse> findAllFixExtension() {
-        return fixExtensionRepository.findAllByOrderByIdAsc().stream()
-            .map(FixExtensionGetResponse::fromEntity)
-            .collect(Collectors.toList());
-    }
 
     @Transactional
     public FixExtensionCreateResponse createFixExtension(FixExtensionCreateRequest fixExtensionCreateRequest) {
@@ -37,6 +31,12 @@ public class FixExtensionService {
         FixExtension fixExtension = fixExtensionDeleteRequest.toEntity();
         fixExtensionRepository.deleteByName(fixExtensionDeleteRequest.getName());
         return FixExtensionDeleteResponse.fromEntity(fixExtension);
+    }
+    @Transactional(readOnly = true)
+    public List<FixExtensionGetResponse> findAllFixExtension() {
+        return fixExtensionRepository.findAllByOrderByIdAsc().stream()
+            .map(FixExtensionGetResponse::fromEntity)
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/flowhyemin/extensionfilter/global/controller/HomeController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/global/controller/HomeController.java
@@ -1,5 +1,6 @@
 package com.flowhyemin.extensionfilter.global.controller;
 
+import com.flowhyemin.extensionfilter.domain.customextension.dto.CustomExtensionGetResponse;
 import com.flowhyemin.extensionfilter.domain.customextension.entity.CustomExtension;
 import com.flowhyemin.extensionfilter.domain.customextension.service.CustomExtensionService;
 import com.flowhyemin.extensionfilter.domain.fixextension.dto.FixExtensionGetResponse;
@@ -20,7 +21,7 @@ public class HomeController {
     @GetMapping("/")
     public String home(Model model) {
         List<FixExtensionGetResponse> fixExtensionList = fixExtensionService.findAllFixExtension();
-        List<CustomExtension> customList = customExtensionService.findAllCustomExtension();
+        List<CustomExtensionGetResponse> customList = customExtensionService.findAllCustomExtension();
 
         model.addAttribute("fixList", fixExtensionList);
         model.addAttribute("customList", customList);

--- a/src/main/java/com/flowhyemin/extensionfilter/global/exception/ErrorCode.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/global/exception/ErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
     //커스텀 확장자
     DUPLICATED_CUSTOM_EXTENSION(1001, "이미 등록된 확장자입니다."),
-    EXCEEDED_CUSTOM_EXTENSION_REGISTRAION(1002,"등록 가능한 커스텀 확장자 수를 초과했습니다.")
+    EXCEEDED_CUSTOM_EXTENSION_REGISTRAION(1002,"등록 가능한 커스텀 확장자 수를 초과했습니다."),
+    NONE_EXISTENCE_CUSTOM_EXTENSION(1003, "입력한 커스텀 확장자는 등록되어 있지 않습니다.")
 
     ;
 


### PR DESCRIPTION
## 작업 요약
- 커스텀 확장자 삭제 시 예외처리 구현
- ex) 미등록 확장자 삭제 요청 방지,글자수(1~20자),영문소문자로만 요청하도록 처리
## Issue Link
#10 
## 문제점 및 어려움
- 없음
## 해결 방안
- 없음
## Reference
