### PR TITLE
Feat : [#issueNumber-11] 고정확장자 예외처리 로직 구현

### DIFF
--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionCreateRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionCreateRequest.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CustomExtensionCreateRequest {
     @Size(min = 1,max = 20,message = "크기가 1에서 20 사이여야 합니다.")
-    @Pattern(regexp = "^[a-z]+$", message = "영어 소문자만 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
 
     public CustomExtension toEntity() {

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionDeleteRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/dto/CustomExtensionDeleteRequest.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CustomExtensionDeleteRequest {
     @Size(min = 1,max = 20,message = "크기가 1에서 20 사이여야 합니다.")
-    @Pattern(regexp = "^[a-z]+$", message = "영어 소문자만 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
 
     public CustomExtension toEntity() {

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/service/CustomExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/customextension/service/CustomExtensionService.java
@@ -23,7 +23,7 @@ public class CustomExtensionService {
     public CustomExtensionCreateResponse createCustomExtension(CustomExtensionCreateRequest customExtensionCreateRequest) {
         if (customExtensionRepository.findByName(customExtensionCreateRequest.getName()).isPresent()
             || fixExtensionRepository.findByName(customExtensionCreateRequest.getName()).isPresent()) {
-            throw new CustomExtensionException(ErrorCode.DUPLICATED_CUSTOM_EXTENSION);
+            throw new CustomExtensionException(ErrorCode.DUPLICATED_EXTENSION);
         }
         if (customExtensionRepository.findAll().size() >= 200) {
             throw new CustomExtensionException(ErrorCode.EXCEEDED_CUSTOM_EXTENSION_REGISTRAION);
@@ -37,7 +37,7 @@ public class CustomExtensionService {
         CustomExtension customExtension = customExtensionRepository.findByName(customExtensionDeleteRequest.getName())
             .orElseThrow(() -> new CustomExtensionException(ErrorCode.NONE_EXISTENCE_CUSTOM_EXTENSION)
         );
-        customExtensionRepository.deleteByName(customExtensionDeleteRequest.getName());
+        customExtensionRepository.delete(customExtension);
         return CustomExtensionDeleteResponse.fromEntity(customExtension);
     }
     @Transactional

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/controller/FixExtensionController.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/controller/FixExtensionController.java
@@ -23,14 +23,14 @@ public class FixExtensionController {
     }
     @PutMapping("/check/")
     @ResponseBody
-    public boolean checkFixExtension(@RequestBody FixExtensionCheckRequest fixExtensionCheckRequest) {
+    public boolean checkFixExtension(@Valid @RequestBody FixExtensionCheckRequest fixExtensionCheckRequest) {
         fixExtensionService.checkFixExtension(fixExtensionCheckRequest);
         return true;
     }
 
     @DeleteMapping("/")
     @ResponseBody
-    public boolean deleteFixExtension(@RequestBody FixExtensionDeleteRequest fixExtensionDeleteRequest) {
+    public boolean deleteFixExtension(@Valid @RequestBody FixExtensionDeleteRequest fixExtensionDeleteRequest) {
         fixExtensionService.deleteFixExtension(fixExtensionDeleteRequest);
         return true;
     }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckRequest.java
@@ -1,6 +1,7 @@
 package com.flowhyemin.extensionfilter.domain.fixextension.dto;
 
 import com.flowhyemin.extensionfilter.domain.fixextension.entity.FixExtension;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -12,9 +13,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class FixExtensionCheckRequest {
-    @Size(min = 1,max = 20)
-    @Pattern(regexp = "^[a-z]+$", message = "영어 소문자만 입력해주세요.")
+    @Size(min = 1,max = 20,message = "크기가 1에서 20 사이여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
+    @NotNull
     private String isChecked;
 
     public FixExtension toEntity() {

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateRequest.java
@@ -1,6 +1,8 @@
 package com.flowhyemin.extensionfilter.domain.fixextension.dto;
 
 import com.flowhyemin.extensionfilter.domain.fixextension.entity.FixExtension;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class FixExtensionCreateRequest {
+    @Size(min = 1,max = 20,message = "크기가 1에서 20 사이여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
 
     public FixExtension toEntity() {

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionDeleteRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionDeleteRequest.java
@@ -2,6 +2,8 @@ package com.flowhyemin.extensionfilter.domain.fixextension.dto;
 
 import com.flowhyemin.extensionfilter.domain.customextension.entity.CustomExtension;
 import com.flowhyemin.extensionfilter.domain.fixextension.entity.FixExtension;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,6 +13,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class FixExtensionDeleteRequest {
+    @Size(min = 1,max = 20,message = "크기가 1에서 20 사이여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
 
     public FixExtension toEntity() {

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/entity/FixExtension.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/entity/FixExtension.java
@@ -20,7 +20,7 @@ public class FixExtension {
     @ColumnDefault("false")
     private String isChecked;
 
-    public void updateFixExtension(String isChecked) {
+    public void updateFixExtensionCheckBox(String isChecked) {
         this.isChecked = isChecked;
     }
 }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/exception/FixExtensionException.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/exception/FixExtensionException.java
@@ -1,0 +1,14 @@
+package com.flowhyemin.extensionfilter.domain.fixextension.exception;
+
+import com.flowhyemin.extensionfilter.global.exception.BaseException;
+import com.flowhyemin.extensionfilter.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class FixExtensionException extends BaseException {
+    private final ErrorCode errorCode;
+    public FixExtensionException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/exception/SampleException.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/exception/SampleException.java
@@ -1,4 +1,0 @@
-package com.flowhyemin.extensionfilter.domain.fixextension.exception;
-
-public class SampleException {
-}

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/repository/FixExtensionRepository.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/repository/FixExtensionRepository.java
@@ -8,14 +8,7 @@ import java.util.Optional;
 
 public interface FixExtensionRepository extends JpaRepository<FixExtension,Long> {
 
-    List<FixExtension> findAllByIsChecked(String ischecked);
-
     Optional<FixExtension> findByName(String name);
-
-
-    void deleteByName(String name);
-
-
     List<FixExtension> findAllByOrderByIdAsc();
 }
 

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
@@ -1,8 +1,11 @@
 package com.flowhyemin.extensionfilter.domain.fixextension.service;
 
+import com.flowhyemin.extensionfilter.domain.customextension.repository.CustomExtensionRepository;
 import com.flowhyemin.extensionfilter.domain.fixextension.dto.*;
 import com.flowhyemin.extensionfilter.domain.fixextension.entity.FixExtension;
+import com.flowhyemin.extensionfilter.domain.fixextension.exception.FixExtensionException;
 import com.flowhyemin.extensionfilter.domain.fixextension.repository.FixExtensionRepository;
+import com.flowhyemin.extensionfilter.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,22 +17,32 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FixExtensionService {
     private final FixExtensionRepository fixExtensionRepository;
+    private final CustomExtensionRepository customExtensionRepository;
 
     @Transactional
     public FixExtensionCreateResponse createFixExtension(FixExtensionCreateRequest fixExtensionCreateRequest) {
-        FixExtension fixExtension = fixExtensionCreateRequest.toEntity();
-        fixExtensionRepository.save(fixExtension);
+        if (fixExtensionRepository.findByName(fixExtensionCreateRequest.getName()).isPresent()
+            || customExtensionRepository.findByName(fixExtensionCreateRequest.getName()).isPresent()) {
+            throw new FixExtensionException(ErrorCode.DUPLICATED_EXTENSION);
+        }
+        if (fixExtensionRepository.findAll().size() >= 20) {
+            throw new FixExtensionException(ErrorCode.EXCEEDED_FIX_EXTENSION_REGISTRAION);
+        }
+        FixExtension fixExtension = fixExtensionRepository.save(fixExtensionCreateRequest.toEntity());
         return FixExtensionCreateResponse.fromEntity(fixExtension);
     }
     @Transactional
-    public void checkFixExtension(FixExtensionCheckRequest fixExtensionCheckRequest) {
-        FixExtension fixExtension = fixExtensionRepository.findByName(fixExtensionCheckRequest.getName()).orElseThrow();
-        fixExtension.updateFixExtension(fixExtensionCheckRequest.getIsChecked());
+    public FixExtensionCheckResponse checkFixExtension(FixExtensionCheckRequest fixExtensionCheckRequest) {
+        FixExtension fixExtension = fixExtensionRepository.findByName(fixExtensionCheckRequest.getName())
+            .orElseThrow(() -> new FixExtensionException(ErrorCode.NONE_EXISTENCE_FIX_EXTENSION));
+        fixExtension.updateFixExtensionCheckBox(fixExtensionCheckRequest.getIsChecked());
+        return FixExtensionCheckResponse.fromEntity(fixExtension);
     }
     @Transactional
     public FixExtensionDeleteResponse deleteFixExtension(FixExtensionDeleteRequest fixExtensionDeleteRequest) {
-        FixExtension fixExtension = fixExtensionDeleteRequest.toEntity();
-        fixExtensionRepository.deleteByName(fixExtensionDeleteRequest.getName());
+        FixExtension fixExtension = fixExtensionRepository.findByName(fixExtensionDeleteRequest.getName())
+            .orElseThrow(() -> new FixExtensionException(ErrorCode.NONE_EXISTENCE_FIX_EXTENSION));
+        fixExtensionRepository.delete(fixExtension);
         return FixExtensionDeleteResponse.fromEntity(fixExtension);
     }
     @Transactional(readOnly = true)

--- a/src/main/java/com/flowhyemin/extensionfilter/global/exception/ErrorCode.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/global/exception/ErrorCode.java
@@ -6,11 +6,16 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    //커스텀 확장자
-    DUPLICATED_CUSTOM_EXTENSION(1001, "이미 등록된 확장자입니다."),
-    EXCEEDED_CUSTOM_EXTENSION_REGISTRAION(1002,"등록 가능한 커스텀 확장자 수를 초과했습니다."),
-    NONE_EXISTENCE_CUSTOM_EXTENSION(1003, "입력한 커스텀 확장자는 등록되어 있지 않습니다.")
+    // 공통
+    DUPLICATED_EXTENSION(1001, "이미 등록된 확장자입니다."),
 
+    //커스텀 확장자
+    EXCEEDED_CUSTOM_EXTENSION_REGISTRAION(1002,"등록 가능한 커스텀 확장자 수를 초과했습니다."),
+    NONE_EXISTENCE_CUSTOM_EXTENSION(1003, "입력한 커스텀 확장자는 등록되어 있지 않습니다."),
+
+    //고정 확장자
+    EXCEEDED_FIX_EXTENSION_REGISTRAION(1004,"등록 가능한 고정 확장자 수를 초과했습니다."),
+    NONE_EXISTENCE_FIX_EXTENSION(1005, "입력한 고정 확장자는 등록되어 있지 않습니다.")
     ;
 
     private final Integer code;

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -292,7 +292,7 @@ function addFixExtension(newFixName) {
  * @returns boolean
  */
 function extensionValidateCheck(name) {
-  const regex = /^[a-z]+$/;
+  const regex = /^[a-zA-Z]+$/;
 
   if (regex.test(name)) {
     return true;


### PR DESCRIPTION
## 작업 요약
- 고정 확장자 등록/체크/삭제 시 예외처리 구현
- ex) 미등록 확장자 삭제 요청 방지,글자수(1~20자),영문대소문자로만 요청하도록 처리,중복 등록 방지,빈값 등록 방지,최대 등록 개수 20개 제한
- 확장자명에 영문대문자 가능하도록 변경
## Issue Link
#11 
## 문제점 및 어려움
1. 대문자 확장자의 경우, 차단 방법이 모호함
## 해결 방안
1. 차단 확장자 등록 시 대문자도 등록 가능하도록 수정
## Reference
