### PR TITLE
Refactor : [#issueNumber-15] 고정확장자 삭제로직 백엔드 코드 개선

### DIFF
--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckRequest.java
@@ -17,7 +17,7 @@ public class FixExtensionCheckRequest {
     @Pattern(regexp = "^[a-zA-Z]+$", message = "영어 소문자만 입력해주세요.")
     private String name;
     @NotNull
-    private String isChecked;
+    private Boolean isChecked;
 
     public FixExtension toEntity() {
         return FixExtension.builder()

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckResponse.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCheckResponse.java
@@ -10,7 +10,7 @@ import lombok.*;
 public class FixExtensionCheckResponse {
     private Long id;
     private String name;
-    private String isChecked;
+    private Boolean isChecked;
 
     public static FixExtensionCheckResponse fromEntity(FixExtension fixExtension) {
         return FixExtensionCheckResponse.builder()

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateRequest.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateRequest.java
@@ -19,7 +19,7 @@ public class FixExtensionCreateRequest {
     public FixExtension toEntity() {
         return FixExtension.builder()
             .name(name)
-            .isChecked("false")
+            .isChecked(false)
             .build();
     }
 }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateResponse.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionCreateResponse.java
@@ -10,7 +10,7 @@ import lombok.*;
 public class FixExtensionCreateResponse {
     private Long id;
     private String name;
-    private String isChecked;
+    private Boolean isChecked;
 
     public static FixExtensionCreateResponse fromEntity(FixExtension fixExtension) {
         return FixExtensionCreateResponse.builder()

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionGetResponse.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/dto/FixExtensionGetResponse.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Builder
 public class FixExtensionGetResponse {
     private String name;
-    private String isChecked;
+    private Boolean isChecked;
 
     public static FixExtensionGetResponse fromEntity(FixExtension fixExtension) {
         return FixExtensionGetResponse.builder()

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/entity/FixExtension.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/entity/FixExtension.java
@@ -18,9 +18,9 @@ public class FixExtension {
     private String name;
     @Column(nullable = false)
     @ColumnDefault("false")
-    private String isChecked;
+    private Boolean isChecked;
 
-    public void updateFixExtensionCheckBox(String isChecked) {
+    public void updateFixExtensionCheckBox(Boolean isChecked) {
         this.isChecked = isChecked;
     }
 }

--- a/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/domain/fixextension/service/FixExtensionService.java
@@ -42,6 +42,9 @@ public class FixExtensionService {
     public FixExtensionDeleteResponse deleteFixExtension(FixExtensionDeleteRequest fixExtensionDeleteRequest) {
         FixExtension fixExtension = fixExtensionRepository.findByName(fixExtensionDeleteRequest.getName())
             .orElseThrow(() -> new FixExtensionException(ErrorCode.NONE_EXISTENCE_FIX_EXTENSION));
+        if (Boolean.TRUE.equals(fixExtension.getIsChecked())) {
+            throw new FixExtensionException(ErrorCode.CHECKED_FIX_EXTENSION);
+        }
         fixExtensionRepository.delete(fixExtension);
         return FixExtensionDeleteResponse.fromEntity(fixExtension);
     }

--- a/src/main/java/com/flowhyemin/extensionfilter/global/exception/ErrorCode.java
+++ b/src/main/java/com/flowhyemin/extensionfilter/global/exception/ErrorCode.java
@@ -15,7 +15,8 @@ public enum ErrorCode {
 
     //고정 확장자
     EXCEEDED_FIX_EXTENSION_REGISTRAION(1004,"등록 가능한 고정 확장자 수를 초과했습니다."),
-    NONE_EXISTENCE_FIX_EXTENSION(1005, "입력한 고정 확장자는 등록되어 있지 않습니다.")
+    NONE_EXISTENCE_FIX_EXTENSION(1005, "입력한 고정 확장자는 등록되어 있지 않습니다."),
+    CHECKED_FIX_EXTENSION(1006,"고정 확장자는 UNCHECK 상태에서 삭제해야합니다.")
     ;
 
     private final Integer code;


### PR DESCRIPTION
## 작업 요약
- 고정 확장자 삭제 시 uncheck된 상태에서만 삭제가능하도록 개선 (백엔드)
## Issue Link
#15 
## 문제점 및 어려움

## 해결 방안

## Reference
